### PR TITLE
Added explicit set for platform to solve Apple Silicon/ARM issue

### DIFF
--- a/src/test/kotlin/io/kotest/extensions/testcontainers/KafkaTestContainerExtensionTest.kt
+++ b/src/test/kotlin/io/kotest/extensions/testcontainers/KafkaTestContainerExtensionTest.kt
@@ -8,14 +8,16 @@ import io.kotest.matchers.collections.shouldHaveSize
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.utility.DockerImageName
 import java.time.Duration
 
 class KafkaTestContainerExtensionTest : FunSpec() {
    init {
 
-      val kafka = install(TestContainerExtension(KafkaContainer("6.2.1"))) {
+      val kafka = install(TestContainerExtension(KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1")))) {
          withEmbeddedZookeeper()
          withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "true")
+         withCreateContainerCmdModifier { it.withPlatform("linux/amd64") }
       }
 
       test("should setup kafka") {


### PR DESCRIPTION
Kafka does not upload a version for ARM architecture. Computers running MacOS with Apple Silicon (ARM architecture) fail to have their containers start. Adding in an explicit set for the linux/amd64 version solves the issue.